### PR TITLE
Case mismatch between loaded and declared class names

### DIFF
--- a/src/Services/Generator/Php.php
+++ b/src/Services/Generator/Php.php
@@ -2,7 +2,7 @@
 
 namespace Frosh\WebP\Services\Generator;
 
-class PHP implements WebPGeneratorInterface
+class Php implements WebPGeneratorInterface
 {
     public function generate($thumbnail, int $quality): string
     {


### PR DESCRIPTION
#### Issue

`Case mismatch between loaded and declared class names: "Frosh\WebP\Services\Generator\Php" vs "Frosh\WebP\Services\Generator\PHP".`

<details>
  <summary>CLI</summary>

  ![grafik](https://user-images.githubusercontent.com/13335308/75026672-a864d300-549d-11ea-9eae-d48b70979cac.png)
</details>

<details>
  <summary>Admin</summary>

  ![grafik](https://user-images.githubusercontent.com/13335308/75027614-25447c80-549f-11ea-98ac-0162cb828857.png)
</details>

#### With this change

<details>
  <summary>CLI</summary>

  ![grafik](https://user-images.githubusercontent.com/13335308/75028278-46f23380-54a0-11ea-9f3d-738590d2f695.png)
</details>

#### System

| | |
|---|---|
| Shopware | shopware/development@6.1.3 |
| OS | macOS 10.15.2 |
| PHP |  7.4.1 |
| Type | [Local installation](https://docs.shopware.com/en/shopware-platform-dev-en/getting-started/installation-guide#local-installation) |